### PR TITLE
PROD-599: New block `scoutos:slack:get_user_info`

### DIFF
--- a/scoutos/blocks/__init__.py
+++ b/scoutos/blocks/__init__.py
@@ -1,4 +1,4 @@
-from .base import Block, BlockBaseConfig, BlockInitializationError
+from .base import Block, BlockBaseConfig, BlockExecutionError, BlockInitializationError
 from .function import Function
 from .http import Http
 from .identity import Identity
@@ -9,6 +9,7 @@ from .template import Template
 __all__ = [
     "Block",
     "BlockBaseConfig",
+    "BlockExecutionError",
     "BlockInitializationError",
     "Function",
     "Http",

--- a/scoutos/blocks/base.py
+++ b/scoutos/blocks/base.py
@@ -213,6 +213,10 @@ class Block(ABC, Generic[RunInput, RunOutput], metaclass=BlockMeta):
         """Run the block. This is the meat and potatos. Yum yum."""
 
 
+class BlockExecutionError(Exception):
+    """Raised when a block raises during execution"""
+
+
 class BlockInitializationError(Exception):
     """This is raised when blocks have not been initialized correctly."""
 

--- a/scoutos/blocks/slack/__init__.py
+++ b/scoutos/blocks/slack/__init__.py
@@ -1,0 +1,5 @@
+from .get_user_info import GetUserInfo
+
+__all__ = [
+    "GetUserInfo",
+]

--- a/scoutos/blocks/slack/base.py
+++ b/scoutos/blocks/slack/base.py
@@ -15,4 +15,13 @@ class Slack(Block[RunInput, RunOutput]):
     _is_base_class = True
 
     def __init__(self, config: SlackConfig):
-        self._config = config
+        super().__init__(config)
+        self._config: SlackConfig = config
+
+    @property
+    def _http_api_url(self) -> str:
+        return "https://slack.com/api"
+
+    @property
+    def _headers(self) -> dict:
+        return {"Authorization": f"Bearer {self._config['token']}"}

--- a/scoutos/blocks/slack/base.py
+++ b/scoutos/blocks/slack/base.py
@@ -1,0 +1,18 @@
+from typing import TypeVar
+
+from scoutos.blocks import Block, BlockBaseConfig
+
+RunInput = TypeVar("RunInput")
+RunOutput = TypeVar("RunOutput")
+
+
+class SlackConfig(BlockBaseConfig):
+    token: str
+    """Slack token required to interact with API"""
+
+
+class Slack(Block[RunInput, RunOutput]):
+    _is_base_class = True
+
+    def __init__(self, config: SlackConfig):
+        self._config = config

--- a/scoutos/blocks/slack/get_user_info.py
+++ b/scoutos/blocks/slack/get_user_info.py
@@ -1,0 +1,58 @@
+import httpx
+from pydantic import TypeAdapter, ValidationError
+from typing_extensions import TypedDict
+
+from scoutos.blocks import BlockExecutionError
+
+from .base import Slack
+
+
+class GetUserInfoInput(TypedDict):
+    user_id: str
+
+
+class GetUserInfoOutput(TypedDict):
+    deleted: bool
+    id: str
+    is_admin: bool
+    is_bot: bool
+    is_owner: bool
+    is_primary_owner: bool
+    name: str
+    real_name: str
+    team_id: str
+
+
+input_adapter = TypeAdapter(GetUserInfoInput)
+output_adapter = TypeAdapter(GetUserInfoOutput)
+
+
+class GetUserInfo(Slack):
+    TYPE = "scoutos:slack:get_user_info"
+
+    async def run(self, run_input: dict) -> GetUserInfoOutput:
+        validated_input = input_adapter.validate_python(run_input)
+
+        headers = self._headers
+        params = {"user": validated_input["user_id"]}
+        url = f"{self._http_api_url}/users.info"
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, headers=headers, params=params)
+                response.raise_for_status()
+
+                data = response.json()
+
+                if not data.get("ok"):
+                    message = data.get("error", "An unknown exception occurred")
+                    raise BlockExecutionError(message)
+
+                return output_adapter.validate_python(data.get("user", {}))
+
+            except ValidationError as validation_error:
+                message = "output failed data validation"
+                raise BlockExecutionError(message) from validation_error
+            except httpx.HTTPStatusError as http_status_error:
+                message = "http request failed"
+                raise BlockExecutionError(message) from http_status_error

--- a/tests/blocks/slack/test_get_user_info.py
+++ b/tests/blocks/slack/test_get_user_info.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from scoutos.blocks import BlockExecutionError
+from scoutos.blocks.slack import GetUserInfo
+
+FAKE_SLACK_TOKEN = "xoxb-***"  # noqa: S105
+FAKE_USER_ID = "UXXXXXXXXXX"
+STUBBED_USER_INFO = {
+    "ok": True,
+    "user": {
+        "deleted": False,
+        "id": "UXXXXXXXXXX",
+        "is_admin": True,
+        "is_bot": False,
+        "is_owner": True,
+        "is_primary_owner": False,
+        "name": "someuser",
+        "real_name": "Some User",
+        "team_id": "TXXXXXXXXXX",
+    },
+}
+
+
+@pytest.fixture()
+def block():
+    return GetUserInfo(
+        {
+            "key": "slack_get_user_info",
+            "token": FAKE_SLACK_TOKEN,
+        }
+    )
+
+
+def mock_response(
+    *,
+    status: int = 200,
+    json: dict | None = STUBBED_USER_INFO,
+    text: str | None = None,
+):
+    if text:
+        response = httpx.Response(status, text=text)
+    else:
+        response = httpx.Response(status, json=json)
+
+    response._request = httpx.Request("GET", "https://slack.com/api/users.info")  # noqa: SLF001
+
+    return response
+
+
+@pytest.fixture()
+def stubbed_response_valid():
+    return {}
+
+
+@pytest.mark.asyncio()
+async def test_it_makes_expected_request_when_run(block):
+    with patch(
+        "scoutos.blocks.slack.get_user_info.httpx.AsyncClient.get",
+        return_value=mock_response(),
+    ) as request:
+        await block.run({"user_id": FAKE_USER_ID})
+
+        request.assert_called_once_with(
+            "https://slack.com/api/users.info",
+            headers={"Authorization": f"Bearer {FAKE_SLACK_TOKEN}"},
+            params={"user": FAKE_USER_ID},
+        )
+
+
+@pytest.mark.asyncio()
+async def test_it_strips_extra_keys_from_user_data(block):
+    user_info_with_extra = STUBBED_USER_INFO.copy()
+    user_info_with_extra["user"]["extra_key"] = "I am an extra key"
+    with patch(
+        "scoutos.blocks.slack.get_user_info.httpx.AsyncClient.get",
+        return_value=mock_response(json=user_info_with_extra),
+    ):
+        result = await block.run({"user_id": FAKE_USER_ID})
+
+        assert result.get("extra_key") is None
+
+
+@pytest.mark.asyncio()
+async def test_when_user_does_not_exist(block):
+    with patch(
+        "scoutos.blocks.slack.get_user_info.httpx.AsyncClient.get",
+        return_value=mock_response(json={"ok": False, "error": "user_not_found"}),
+    ), pytest.raises(BlockExecutionError, match="user_not_found"):
+        await block.run({"user_id": FAKE_USER_ID})
+
+
+@pytest.mark.asyncio()
+async def test_when_request_fails(block):
+    with patch(
+        "scoutos.blocks.slack.get_user_info.httpx.AsyncClient.get",
+        return_value=mock_response(status=500, text="Internal Server Error"),
+    ), pytest.raises(BlockExecutionError, match="http request failed"):
+        await block.run({"user_id": FAKE_USER_ID})
+
+
+@pytest.mark.asyncio()
+async def test_when_invalid_user_data_returned(block):
+    stubbed_response = {"ok": True, "user": {}}
+    with patch(
+        "scoutos.blocks.slack.get_user_info.httpx.AsyncClient.get",
+        return_value=mock_response(status=200, json=stubbed_response),
+    ), pytest.raises(BlockExecutionError, match="output failed data validation"):
+        await block.run({"user_id": FAKE_USER_ID})

--- a/tests/blocks/slack/test_slack_base.py
+++ b/tests/blocks/slack/test_slack_base.py
@@ -1,0 +1,21 @@
+from scoutos.blocks import Block
+from scoutos.blocks.slack.base import Slack
+
+
+def test_extending_from_base():
+    class SomeSlackBlock(Slack[dict, dict]):
+        TYPE = "scoutos:slack:some_block"
+
+        async def run(self, run_input: dict) -> dict:
+            return run_input
+
+    block = SomeSlackBlock(
+        {
+            "key": "some_slack_block",
+            "token": "FAKE_SLACK_TOKEN",
+        }
+    )
+
+    assert isinstance(block, Block)
+    assert isinstance(block, Slack)
+    assert isinstance(block, SomeSlackBlock)

--- a/tests/blocks/slack/test_slack_base.py
+++ b/tests/blocks/slack/test_slack_base.py
@@ -1,21 +1,35 @@
+import pytest
+
 from scoutos.blocks import Block
 from scoutos.blocks.slack.base import Slack
 
+FAKE_SLACK_TOKEN = "xoxb-***"  # noqa: S105
 
-def test_extending_from_base():
+
+@pytest.fixture()
+def block():
     class SomeSlackBlock(Slack[dict, dict]):
         TYPE = "scoutos:slack:some_block"
 
         async def run(self, run_input: dict) -> dict:
             return run_input
 
-    block = SomeSlackBlock(
+    return SomeSlackBlock(
         {
             "key": "some_slack_block",
-            "token": "FAKE_SLACK_TOKEN",
+            "token": FAKE_SLACK_TOKEN,
         }
     )
 
+
+def test_inheritence(block):
     assert isinstance(block, Block)
     assert isinstance(block, Slack)
-    assert isinstance(block, SomeSlackBlock)
+
+
+def test_it_defines_http_api_url_correctly(block):
+    assert block._http_api_url == "https://slack.com/api"  # noqa: SLF001
+
+
+def test_it_defines_headers_correctly(block):
+    assert block._headers == {"Authorization": f"Bearer {FAKE_SLACK_TOKEN}"}  # noqa: SLF001


### PR DESCRIPTION
## Ticket

https://linear.app/scoutshq/issue/PROD-599/block-slack-get-user-info

## What / Why?

Created a new block `scoutos:slack:get_user_info` that when run with required configuration, returns the user info for a given slack user.

## Usage

```python
from scoutos.blocks.slack import GetUserInfo


async def main():
    slack_token = "xobx-***"
    user_id = "UXXXXXXXXXX"

    block = GetUserInfo(
        {
            "key": "slack_get_user_info",
            "token": slack_token,
        }
    )
    user_info = await block.run({"user_id": user_id})

    # user_info is validated and has the following attributes
    #   deleted: bool
    #   id: str
    #   is_admin: bool
    #   is_bot: bool
    #   is_owner: bool
    #   is_primary_owner: bool
    #   name: str
    #   real_name: str
    #   team_id: str
```