### PR TITLE
docs: update python version requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Build LLM Apps
 
 ## Requirements
 
-- Python ^3.11
+- Python ^3.10
 
 ## Installation
 


### PR DESCRIPTION
## What / Why?

After making SDK compatible with Python 3.10 in #10, I forgot to update the `README` to reflect the correct minimum version. Correcting.
