### PR TITLE
PROD-600: New Block `scoutos:slack:get_channels`

### DIFF
--- a/scoutos/blocks/slack/__init__.py
+++ b/scoutos/blocks/slack/__init__.py
@@ -1,5 +1,8 @@
+from .get_channels import GetChannels, GetChannelsConfig
 from .get_user_info import GetUserInfo
 
 __all__ = [
+    "GetChannels",
+    "GetChannelsConfig",
     "GetUserInfo",
 ]

--- a/scoutos/blocks/slack/get_channels.py
+++ b/scoutos/blocks/slack/get_channels.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import httpx
+from pydantic import ValidationError
+
+from scoutos.blocks import BlockExecutionError
+
+from .base import Slack
+from .types import Channel
+
+
+class GetChannels(Slack):
+    TYPE = "scoutos:slack:get_channels"
+
+    async def run(self, _run_input: dict) -> list[Channel]:
+        headers = self._headers
+        params = {"limit": 1000}  # Note: This is the maximum allowed
+        url = f"{self._http_api_url}/conversations.list"
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.get(url, headers=headers, params=params)
+                response.raise_for_status()
+
+                data = response.json()
+
+                if not data.get("ok"):
+                    message = data.get("error", "An unknown exception occurred")
+                    raise BlockExecutionError(message)
+
+                return [
+                    Channel(**channel_data) for channel_data in data.get("channels", [])
+                ]
+
+            except ValidationError as validation_error:
+                message = "output failed data validation"
+                raise BlockExecutionError(message) from validation_error
+            except httpx.HTTPStatusError as http_status_error:
+                message = "http request failed"
+                raise BlockExecutionError(message) from http_status_error

--- a/scoutos/blocks/slack/get_channels.py
+++ b/scoutos/blocks/slack/get_channels.py
@@ -32,13 +32,12 @@ class GetChannels(Slack):
                     message = data.get("error", "An unknown exception occurred")
                     raise BlockExecutionError(message)
 
-                # import json
-                #
-                # print(json.dumps(data, indent=2))
+                channel_data = data.get("channels")
+                if not channel_data or not isinstance(channel_data, list):
+                    message = "no channels returned"
+                    raise BlockExecutionError(message)
 
-                return [
-                    Channel(**channel_data) for channel_data in data.get("channels", [])
-                ]
+                return [Channel(**channel_datum) for channel_datum in channel_data]
 
             except ValidationError as validation_error:
                 message = "output failed data validation"

--- a/scoutos/blocks/slack/get_channels.py
+++ b/scoutos/blocks/slack/get_channels.py
@@ -5,8 +5,12 @@ from pydantic import ValidationError
 
 from scoutos.blocks import BlockExecutionError
 
-from .base import Slack
+from .base import Slack, SlackConfig
 from .types import Channel
+
+
+class GetChannelsConfig(SlackConfig):
+    pass
 
 
 class GetChannels(Slack):
@@ -27,6 +31,10 @@ class GetChannels(Slack):
                 if not data.get("ok"):
                     message = data.get("error", "An unknown exception occurred")
                     raise BlockExecutionError(message)
+
+                # import json
+                #
+                # print(json.dumps(data, indent=2))
 
                 return [
                     Channel(**channel_data) for channel_data in data.get("channels", [])

--- a/scoutos/blocks/slack/types.py
+++ b/scoutos/blocks/slack/types.py
@@ -1,8 +1,32 @@
 from pydantic import BaseModel, ConfigDict
 
 
+class ChannelTopic(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    value: str
+    creator: str
+    last_set: int
+
+
 class Channel(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    created: int
     id: str
+    is_archived: bool
+    is_channel: bool
+    is_general: bool
+    is_group: bool
+    is_member: bool
+    is_mpim: bool
+    is_org_shared: bool
+    is_pending_ext_shared: bool
+    is_private: bool
+    is_shared: bool
     name: str
+    name_normalized: str
+    num_members: int
+    purpose: ChannelTopic
+    topic: ChannelTopic
+    unlinked: int

--- a/scoutos/blocks/slack/types.py
+++ b/scoutos/blocks/slack/types.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, ConfigDict
+
+
+class Channel(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: str
+    name: str

--- a/tests/blocks/slack/fixtures/get_channels_payload.json
+++ b/tests/blocks/slack/fixtures/get_channels_payload.json
@@ -1,0 +1,178 @@
+{
+  "ok": true,
+  "channels": [
+    {
+      "id": "C04TK3213RQ",
+      "name": "random",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
+      "is_private": false,
+      "created": 1678654498,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "name_normalized": "random",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T04TMGM7A8L",
+      "updated": 1711677947306,
+      "parent_conversation": null,
+      "creator": "U04T4GQ5LKH",
+      "is_ext_shared": false,
+      "shared_team_ids": ["T04TMGM7A8L"],
+      "pending_connected_team_ids": [],
+      "is_member": false,
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "This channel is for... well, everything else. It\u2019s a place for team jokes, spur-of-the-moment ideas, and funny GIFs. Go wild!",
+        "creator": "U04T4GQ5LKH",
+        "last_set": 1678654498
+      },
+      "properties": {
+        "use_case": "random"
+      },
+      "previous_names": [],
+      "num_members": 5
+    },
+    {
+      "id": "C04TS9MTLUX",
+      "name": "updates",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
+      "is_private": false,
+      "created": 1678933009,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "name_normalized": "updates",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T04TMGM7A8L",
+      "updated": 1693425395040,
+      "parent_conversation": null,
+      "creator": "U04T4GSUAF9",
+      "is_ext_shared": false,
+      "shared_team_ids": ["T04TMGM7A8L"],
+      "pending_connected_team_ids": [],
+      "is_member": false,
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "properties": {
+        "canvas": {
+          "file_id": "F05QB3B8KPD",
+          "is_empty": true,
+          "quip_thread_id": "BMK9AAY7x9w"
+        }
+      },
+      "previous_names": ["linear_updates"],
+      "num_members": 5
+    },
+    {
+      "id": "C04TXMB9F6D",
+      "name": "general",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
+      "is_private": false,
+      "created": 1678654498,
+      "is_archived": false,
+      "is_general": true,
+      "unlinked": 0,
+      "name_normalized": "general",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T04TMGM7A8L",
+      "updated": 1711677947323,
+      "parent_conversation": null,
+      "creator": "U04T4GQ5LKH",
+      "is_ext_shared": false,
+      "shared_team_ids": ["T04TMGM7A8L"],
+      "pending_connected_team_ids": [],
+      "is_member": true,
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "This is the one channel that will always include everyone. It\u2019s a great spot for announcements and team-wide conversations.",
+        "creator": "U04T4GQ5LKH",
+        "last_set": 1678654498
+      },
+      "properties": {
+        "canvas": {
+          "file_id": "F0664N7DFAS",
+          "is_empty": true,
+          "quip_thread_id": "OGf9AAvkyxu"
+        },
+        "use_case": "welcome"
+      },
+      "previous_names": [],
+      "num_members": 11
+    },
+    {
+      "id": "C04UQ9Z6H6Z",
+      "name": "growth",
+      "is_channel": true,
+      "is_group": false,
+      "is_im": false,
+      "is_mpim": false,
+      "is_private": false,
+      "created": 1679330761,
+      "is_archived": false,
+      "is_general": false,
+      "unlinked": 0,
+      "name_normalized": "growth",
+      "is_shared": false,
+      "is_org_shared": false,
+      "is_pending_ext_shared": false,
+      "pending_shared": [],
+      "context_team_id": "T04TMGM7A8L",
+      "updated": 1679330761610,
+      "parent_conversation": null,
+      "creator": "U04T4GQ5LKH",
+      "is_ext_shared": false,
+      "shared_team_ids": ["T04TMGM7A8L"],
+      "pending_connected_team_ids": [],
+      "is_member": true,
+      "topic": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "purpose": {
+        "value": "",
+        "creator": "",
+        "last_set": 0
+      },
+      "previous_names": [],
+      "num_members": 8
+    }
+  ],
+  "response_metadata": {
+    "next_cursor": ""
+  }
+}

--- a/tests/blocks/slack/test_get_channels.py
+++ b/tests/blocks/slack/test_get_channels.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from scoutos.blocks import BlockExecutionError
 from scoutos.blocks.slack import GetChannels
 
 FAKE_SLACK_TOKEN = "xobx-***"  # noqa: S105
@@ -54,13 +55,16 @@ def mock_response(
     return response
 
 
+HTTPX_GET_PATCH_PATH = "scoutos.blocks.slack.get_channels.httpx.AsyncClient.get"
+
+
 @pytest.mark.asyncio()
 async def test_it_makes_expected_request_when_run():
     stubbed_response = mock_response()
     block = create_block()
 
     with patch(
-        "scoutos.blocks.slack.get_channels.httpx.AsyncClient.get",
+        HTTPX_GET_PATCH_PATH,
         return_value=stubbed_response,
     ) as mock_request:
         result = await block.run({})
@@ -73,3 +77,51 @@ async def test_it_makes_expected_request_when_run():
 
         assert isinstance(result, list)
         assert len(result) > 0
+
+
+@pytest.mark.asyncio()
+async def test_when_slack_api_returns_with_error():
+    block = create_block()
+    stubbed_response = mock_response(json={"ok": False, "error": "some_error"})
+
+    with patch(HTTPX_GET_PATCH_PATH, return_value=stubbed_response), pytest.raises(
+        BlockExecutionError, match="some_error"
+    ):
+        await block.run({})
+
+
+@pytest.mark.asyncio()
+async def test_when_request_fails():
+    block = create_block()
+    stubbed_response = mock_response(status=500, text="Internal Server Error")
+
+    with patch(HTTPX_GET_PATCH_PATH, return_value=stubbed_response), pytest.raises(
+        BlockExecutionError, match="http request failed"
+    ):
+        await block.run({})
+
+
+@pytest.mark.asyncio()
+async def test_when_no_channel_data_is_returned():
+    block = create_block()
+    stubbed_response = mock_response(json={"ok": True})
+
+    with patch(HTTPX_GET_PATCH_PATH, return_value=stubbed_response), pytest.raises(
+        BlockExecutionError,
+        match="no channels returned",
+    ):
+        await block.run({})
+
+
+@pytest.mark.asyncio()
+async def test_when_invalid_user_data_returned():
+    block = create_block()
+    stubbed_response = mock_response(
+        json={"ok": True, "channels": [{"missing": "required_keys"}]}
+    )
+
+    with patch(HTTPX_GET_PATCH_PATH, return_value=stubbed_response), pytest.raises(
+        BlockExecutionError,
+        match="output failed data validation",
+    ):
+        await block.run({})

--- a/tests/blocks/slack/test_get_channels.py
+++ b/tests/blocks/slack/test_get_channels.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from scoutos.blocks.slack import GetChannels
+
+FAKE_SLACK_TOKEN = "xobx-***"  # noqa: S105
+
+
+def create_block():
+    return GetChannels(
+        {
+            "key": "slack_get_channels",
+            "token": FAKE_SLACK_TOKEN,
+        }
+    )
+
+
+def get_fixture_path(filename: str) -> Path:
+    """Return the local path for fixtures relative to this text file."""
+    current_dir = Path(__file__).parent
+    fixture_dir = Path.joinpath(current_dir, "fixtures")
+
+    return Path.joinpath(fixture_dir, filename)
+
+
+def get_fixture_contents(fixture_name: str) -> dict:
+    """Return the contents of the given fixture."""
+    fixture_path = get_fixture_path(fixture_name)
+
+    with fixture_path.open("rb") as f:
+        return json.load(f)
+
+
+def mock_response(
+    *,
+    status: int = 200,
+    json: dict | None = None,
+    text: str | None = None,
+):
+    json = json or get_fixture_contents("get_channels_payload.json")
+    if text:
+        response = httpx.Response(status, text=text)
+    else:
+        response = httpx.Response(status, json=json)
+
+    response._request = httpx.Request("GET", "https://slack.com/api/conversations.list")  # noqa: SLF001
+
+    return response
+
+
+@pytest.mark.asyncio()
+async def test_it_makes_expected_request_when_run():
+    stubbed_response = mock_response()
+    block = create_block()
+
+    with patch(
+        "scoutos.blocks.slack.get_channels.httpx.AsyncClient.get",
+        return_value=stubbed_response,
+    ) as mock_request:
+        result = await block.run({})
+
+        mock_request.assert_called_once_with(
+            "https://slack.com/api/conversations.list",
+            headers={"Authorization": f"Bearer {FAKE_SLACK_TOKEN}"},
+            params={"limit": 1000},
+        )
+
+        assert isinstance(result, list)
+        assert len(result) > 0


### PR DESCRIPTION
## Ticket

https://linear.app/scoutshq/issue/PROD-600/block-slack-get-channel-info

## What / Why?

Created a new block `scoutos:slack:get_channels` that when run with required configuration, returns information about channels used in the last 1000 conversations for the authenticated Slack.

## Usage

```python
from scoutos.blocks.slack import GetChannels


async def main():
    slack_token = "xobx-***"

    block = GetChannels(
        {
            "key": "slack_get_channels",
            "token": slack_token,
        }
    )
    channels = await block.run({})
```

Where the channel data is validated and looks like:

```python
class Channel(BaseModel):
    model_config = ConfigDict(extra="allow")

    created: int
    id: str
    is_archived: bool
    is_channel: bool
    is_general: bool
    is_group: bool
    is_member: bool
    is_mpim: bool
    is_org_shared: bool
    is_pending_ext_shared: bool
    is_private: bool
    is_shared: bool
    name: str
    name_normalized: str
    num_members: int
    purpose: ChannelTopic
    topic: ChannelTopic
    unlinked: int
```