### PR TITLE
PROD-597: New Block `scoutos:slack:get_messages`

### DIFF
--- a/scoutos/blocks/slack/__init__.py
+++ b/scoutos/blocks/slack/__init__.py
@@ -1,8 +1,16 @@
 from .get_channels import GetChannels, GetChannelsConfig
+from .get_messages import (
+    GetMessages,
+    GetMessagesConfig,
+    GetMessagesInput,
+)
 from .get_user_info import GetUserInfo
 
 __all__ = [
     "GetChannels",
     "GetChannelsConfig",
+    "GetMessages",
+    "GetMessagesConfig",
+    "GetMessagesInput",
     "GetUserInfo",
 ]

--- a/scoutos/blocks/slack/__init__.py
+++ b/scoutos/blocks/slack/__init__.py
@@ -1,8 +1,8 @@
 from .get_channels import GetChannels, GetChannelsConfig
 from .get_messages import (
     GetMessages,
-    GetMessagesConfig,
     GetMessagesInput,
+    GetMessagesOutput,
 )
 from .get_user_info import GetUserInfo
 
@@ -10,7 +10,7 @@ __all__ = [
     "GetChannels",
     "GetChannelsConfig",
     "GetMessages",
-    "GetMessagesConfig",
     "GetMessagesInput",
+    "GetMessagesOutput",
     "GetUserInfo",
 ]

--- a/scoutos/blocks/slack/get_messages.py
+++ b/scoutos/blocks/slack/get_messages.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import httpx
+from pydantic import BaseModel, ValidationError
+
+from scoutos.blocks import BlockExecutionError
+
+from .base import Slack, SlackConfig
+from .types import Message, ResponseMetadata  # noqa: TCH001
+
+
+class GetMessagesConfig(SlackConfig):
+    channel_id: str
+    """Channel ID to fetch history for."""
+
+
+class GetMessagesInput(BaseModel):
+    cursor: str | None = None
+    """Paginate through collections of data by setting the cursor parameter to
+    a next_cursor attribute returned by a previous request's
+    response_metadata. Default value fetches the first "page" of the
+    collection. See pagination for more detail."""
+
+    latest: str | None = None
+    """Only messages before this Unix timestamp will be included in results.
+    Default is the current time."""
+
+    limit: int | None = 100
+    """The maximum number of items to return. Fewer than the requested number of
+    items may be returned, even if the end of the conversation history
+    hasn't been reached. Maximum of 999."""
+
+    oldest: str | None = None
+    """Only messages after this Unix timestamp will be included in results.
+    Default is '0'.
+    """
+
+
+class GetMessagesOutput(BaseModel):
+    ok: Literal[True]
+    messages: list[Message]
+    has_more: bool
+    pin_count: int
+    response_metadata: ResponseMetadata | None
+
+
+class GetMessages(Slack):
+    TYPE = "scoutos:slack:get_messages"
+
+    def __init__(self, config: GetMessagesConfig):
+        super().__init__(config)
+        self._config: GetMessagesConfig = config
+
+    async def run(self, run_input: dict) -> GetMessagesOutput:
+        validated_input = GetMessagesInput.model_validate(run_input)
+
+        headers = self._headers
+        data = {
+            **validated_input.model_dump(),
+            "channel": self._config["channel_id"],
+        }
+        url = f"{self._http_api_url}/conversations.history"
+
+        async with httpx.AsyncClient() as client:
+            try:
+                response = await client.post(url, headers=headers, json=data)
+                response.raise_for_status()
+
+                data = response.json()
+
+                if not data.get("ok"):
+                    message = data.get("error", "an unknown exception occurred")
+                    raise BlockExecutionError(message)
+
+                return GetMessagesOutput.model_validate(data)
+
+            except ValidationError as validation_error:
+                message = "output failed data validation"
+                raise BlockExecutionError(message) from validation_error
+
+            except httpx.HTTPStatusError as http_status_error:
+                message = "http request failed"
+                raise BlockExecutionError(message) from http_status_error

--- a/scoutos/blocks/slack/types.py
+++ b/scoutos/blocks/slack/types.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pydantic import BaseModel, ConfigDict
 
 
@@ -30,3 +32,11 @@ class Channel(BaseModel):
     purpose: ChannelTopic
     topic: ChannelTopic
     unlinked: int
+
+
+class Message(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+
+class ResponseMetadata(BaseModel):
+    next_cursor: str | None

--- a/tests/blocks/slack/fixtures/get_messages_payload.json
+++ b/tests/blocks/slack/fixtures/get_messages_payload.json
@@ -1,0 +1,276 @@
+{
+  "ok": true,
+  "messages": [
+    {
+      "user": "U05LHSTAJNA",
+      "type": "message",
+      "ts": "1713973667.990189",
+      "client_msg_id": "377e1257-8c84-46c1-a2f5-8b53f18ca473",
+      "text": "New twitter and linkedin post:\n<https://x.com/scoutshq/status/1783160230886486062>\n\n<https://www.linkedin.com/feed/update/urn:li:activity:7188925925990838272>",
+      "team": "T04TMGM7A8L",
+      "attachments": [
+        {
+          "image_url": "https://pbs.twimg.com/media/GL8Ox1UXEAAM_08.jpg:large",
+          "image_width": 1600,
+          "image_height": 900,
+          "image_bytes": 127855,
+          "from_url": "https://x.com/scoutshq/status/1783160230886486062",
+          "service_icon": "http://abs.twimg.com/favicons/twitter.3.ico",
+          "id": 1,
+          "original_url": "https://x.com/scoutshq/status/1783160230886486062",
+          "fallback": "X (formerly Twitter): Scout (@scoutshq) on X",
+          "text": "See what our users are saying about how quick it is to get their AI copilot up and running! @_hyper_io #copilot #LLM #AI #RAG",
+          "title": "Scout (@scoutshq) on X",
+          "title_link": "https://x.com/scoutshq/status/1783160230886486062",
+          "service_name": "X (formerly Twitter)"
+        },
+        {
+          "from_url": "https://www.linkedin.com/feed/update/urn:li:activity:7188925925990838272",
+          "image_url": "https://media.licdn.com/dms/image/D4E10AQGu7bfvQy3FaA/image-shrink_800/0/1713973504345?e=2147483647&v=beta&t=ooP1TomclZMd2_JMrF0dDejMuHSLTNqZ6aeo4mwMvb8",
+          "image_width": 800,
+          "image_height": 450,
+          "image_bytes": 35322,
+          "service_icon": "https://static.licdn.com/aero-v1/sc/h/al2o9zrvru7aqj8e1x2rzsrca",
+          "id": 2,
+          "original_url": "https://www.linkedin.com/feed/update/urn:li:activity:7188925925990838272",
+          "fallback": "Scout on LinkedIn: #copilot #llm #ai #rag",
+          "text": "See what our users are saying about how quick it is to get their AI copilot up and running! hyper\n#copilot #LLM #AI #RAG",
+          "title": "Scout on LinkedIn: #copilot #llm #ai #rag",
+          "title_link": "https://www.linkedin.com/feed/update/urn:li:activity:7188925925990838272",
+          "service_name": "linkedin.com"
+        }
+      ],
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "EgLqq",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "New twitter and linkedin post:\n"
+                },
+                {
+                  "type": "link",
+                  "url": "https://x.com/scoutshq/status/1783160230886486062"
+                },
+                {
+                  "type": "text",
+                  "text": "\n\n"
+                },
+                {
+                  "type": "link",
+                  "url": "https://www.linkedin.com/feed/update/urn:li:activity:7188925925990838272"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "reactions": [
+        {
+          "name": "raised_hands",
+          "users": ["U0502Q12Q1M"],
+          "count": 1
+        },
+        {
+          "name": "white_check_mark",
+          "users": ["U0502Q12Q1M"],
+          "count": 1
+        }
+      ]
+    },
+    {
+      "text": "My goodness",
+      "files": [
+        {
+          "id": "F070H0FJXGU",
+          "created": 1713962928,
+          "timestamp": 1713962928,
+          "name": "Screenshot 2024-04-24 at 8.48.45 AM.png",
+          "title": "Screenshot 2024-04-24 at 8.48.45 AM.png",
+          "mimetype": "image/png",
+          "filetype": "png",
+          "pretty_type": "PNG",
+          "user": "U04T4GQ5LKH",
+          "user_team": "T04TMGM7A8L",
+          "editable": false,
+          "size": 177665,
+          "mode": "hosted",
+          "is_external": false,
+          "external_type": "",
+          "is_public": true,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "username": "",
+          "url_private": "https://files.slack.com/files-pri/T04TMGM7A8L-F070H0FJXGU/screenshot_2024-04-24_at_8.48.45_am.png",
+          "url_private_download": "https://files.slack.com/files-pri/T04TMGM7A8L-F070H0FJXGU/download/screenshot_2024-04-24_at_8.48.45_am.png",
+          "media_display_type": "unknown",
+          "thumb_64": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_64.png",
+          "thumb_80": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_80.png",
+          "thumb_360": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_360.png",
+          "thumb_360_w": 360,
+          "thumb_360_h": 168,
+          "thumb_480": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_480.png",
+          "thumb_480_w": 480,
+          "thumb_480_h": 224,
+          "thumb_160": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_160.png",
+          "thumb_720": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_720.png",
+          "thumb_720_w": 720,
+          "thumb_720_h": 336,
+          "thumb_800": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_800.png",
+          "thumb_800_w": 800,
+          "thumb_800_h": 374,
+          "thumb_960": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_960.png",
+          "thumb_960_w": 960,
+          "thumb_960_h": 448,
+          "thumb_1024": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070H0FJXGU-71efb0924a/screenshot_2024-04-24_at_8.48.45_am_1024.png",
+          "thumb_1024_w": 1024,
+          "thumb_1024_h": 478,
+          "original_w": 2278,
+          "original_h": 1064,
+          "thumb_tiny": "AwAWADDP/hHApCM0o6CigBu00bTTqKAG7TRtp1B6UAICMClyKbRQA7IoyKbRQA7IpCeKSigD/9k=",
+          "permalink": "https://scout-team-hq.slack.com/files/U04T4GQ5LKH/F070H0FJXGU/screenshot_2024-04-24_at_8.48.45_am.png",
+          "permalink_public": "https://slack-files.com/T04TMGM7A8L-F070H0FJXGU-0bebae9e19",
+          "is_starred": false,
+          "has_rich_preview": false,
+          "file_access": "visible"
+        }
+      ],
+      "upload": false,
+      "user": "U04T4GQ5LKH",
+      "display_as_bot": false,
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "c0dWL",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "My goodness"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "type": "message",
+      "ts": "1713962936.207969",
+      "client_msg_id": "60d62db1-871f-4ec0-b8c7-47d0c96e8ee8",
+      "reactions": [
+        {
+          "name": "chart_with_upwards_trend",
+          "users": ["U0502Q12Q1M"],
+          "count": 1
+        },
+        {
+          "name": "muscle",
+          "users": ["U0502Q12Q1M"],
+          "count": 1
+        }
+      ]
+    },
+    {
+      "text": "Created the new updates document for next stand up",
+      "files": [
+        {
+          "id": "F070414MVRC",
+          "created": 1713905579,
+          "timestamp": 1713905579,
+          "name": "Screenshot 2024-04-23 at 4.52.56 PM.png",
+          "title": "Screenshot 2024-04-23 at 4.52.56 PM.png",
+          "mimetype": "image/png",
+          "filetype": "png",
+          "pretty_type": "PNG",
+          "user": "U04T4GQ5LKH",
+          "user_team": "T04TMGM7A8L",
+          "editable": false,
+          "size": 1030983,
+          "mode": "hosted",
+          "is_external": false,
+          "external_type": "",
+          "is_public": true,
+          "public_url_shared": false,
+          "display_as_bot": false,
+          "username": "",
+          "url_private": "https://files.slack.com/files-pri/T04TMGM7A8L-F070414MVRC/screenshot_2024-04-23_at_4.52.56_pm.png",
+          "url_private_download": "https://files.slack.com/files-pri/T04TMGM7A8L-F070414MVRC/download/screenshot_2024-04-23_at_4.52.56_pm.png",
+          "media_display_type": "unknown",
+          "thumb_64": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_64.png",
+          "thumb_80": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_80.png",
+          "thumb_360": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_360.png",
+          "thumb_360_w": 360,
+          "thumb_360_h": 208,
+          "thumb_480": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_480.png",
+          "thumb_480_w": 480,
+          "thumb_480_h": 277,
+          "thumb_160": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_160.png",
+          "thumb_720": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_720.png",
+          "thumb_720_w": 720,
+          "thumb_720_h": 415,
+          "thumb_800": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_800.png",
+          "thumb_800_w": 800,
+          "thumb_800_h": 461,
+          "thumb_960": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_960.png",
+          "thumb_960_w": 960,
+          "thumb_960_h": 554,
+          "thumb_1024": "https://files.slack.com/files-tmb/T04TMGM7A8L-F070414MVRC-4a2b0811dd/screenshot_2024-04-23_at_4.52.56_pm_1024.png",
+          "thumb_1024_w": 1024,
+          "thumb_1024_h": 591,
+          "original_w": 3104,
+          "original_h": 1790,
+          "thumb_tiny": "AwAbADCWxt4XtkZ41YkdxVj7Jb/88U/75qPTz/okY9v6mrVAEBtYB/yxT/vml+ywf88U/wC+alPUUtAEP2W3/wCeKf8AfNQXttClpIyxqCBwQPertV9Q/wCPKX6f1oAbp/8Ax6x/T+tWq5tZZFGFdgPQGl86X/nq/wD30aAOiPUUtc550v8Az1f/AL6NHnS/89X/AO+jQB0dVtQI+xyDuR/UVi+dL/z1f/vo0NLIww0jEHsTQB//2Q==",
+          "permalink": "https://scout-team-hq.slack.com/files/U04T4GQ5LKH/F070414MVRC/screenshot_2024-04-23_at_4.52.56_pm.png",
+          "permalink_public": "https://slack-files.com/T04TMGM7A8L-F070414MVRC-a1098a7170",
+          "is_starred": false,
+          "has_rich_preview": false,
+          "file_access": "visible"
+        }
+      ],
+      "upload": false,
+      "user": "U04T4GQ5LKH",
+      "display_as_bot": false,
+      "blocks": [
+        {
+          "type": "rich_text",
+          "block_id": "5j1Fv",
+          "elements": [
+            {
+              "type": "rich_text_section",
+              "elements": [
+                {
+                  "type": "text",
+                  "text": "Created the new updates document for next stand up"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "type": "message",
+      "ts": "1713905597.438239",
+      "client_msg_id": "b75d14dd-4132-4b35-bb9a-47d2b5838c3b",
+      "reactions": [
+        {
+          "name": "ship",
+          "users": ["U0502Q12Q1M"],
+          "count": 1
+        }
+      ]
+    }
+  ],
+  "has_more": true,
+  "pin_count": 0,
+  "channel_actions_ts": null,
+  "channel_actions_count": 0,
+  "warning": "missing_charset",
+  "response_metadata": {
+    "next_cursor": "bmV4dF90czoxNzEzODk4MzY5MTc3MTM5",
+    "warnings": ["missing_charset"]
+  }
+}

--- a/tests/blocks/slack/test_get_messages.py
+++ b/tests/blocks/slack/test_get_messages.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from scoutos.blocks.slack import GetMessages
+
+FAKE_TOKEN = "xoxb-***"  # noqa: S105
+FAKE_CHANNEL_ID = "CXXX"
+
+HTTPX_POST_PATCH_PATH = "scoutos.blocks.slack.get_messages.httpx.AsyncClient.post"
+
+
+def create_block():
+    return GetMessages(
+        {
+            "key": "slack_get_messages",
+            "token": FAKE_TOKEN,
+            "channel_id": FAKE_CHANNEL_ID,
+        }
+    )
+
+
+def create_stubbed_response(
+    *,
+    status: int = 200,
+    json: dict | None = None,
+    text: str | None = None,
+):
+    if text:
+        response = httpx.Response(status, text=text)
+    else:
+        response = httpx.Response(status, json=json)
+
+    response._request = httpx.Request(  # noqa: SLF001
+        "POST", "https://slack.com/api/conversations.history"
+    )
+
+    return response
+
+
+@pytest.mark.asyncio()
+async def test_happy_path(get_fixture_data):
+    block = create_block()
+    stubbed_response = create_stubbed_response(
+        json=get_fixture_data("tests/blocks/slack/fixtures/get_messages_payload.json")
+    )
+
+    with patch(
+        HTTPX_POST_PATCH_PATH, return_value=stubbed_response
+    ) as mock_http_request:
+        limit = 3
+        result = await block.run({"limit": limit})
+
+        mock_http_request.assert_called_once_with(
+            "https://slack.com/api/conversations.history",
+            headers={"Authorization": f"Bearer {FAKE_TOKEN}"},
+            json={
+                "channel": FAKE_CHANNEL_ID,
+                "cursor": None,
+                "latest": None,
+                "limit": limit,
+                "oldest": None,
+            },
+        )
+
+        assert result is not None

--- a/tests/blocks/slack/test_get_messages.py
+++ b/tests/blocks/slack/test_get_messages.py
@@ -19,7 +19,6 @@ def create_block():
         {
             "key": "slack_get_messages",
             "token": FAKE_TOKEN,
-            "channel_id": FAKE_CHANNEL_ID,
         }
     )
 
@@ -53,7 +52,7 @@ async def test_happy_path(get_fixture_data):
         HTTPX_POST_PATCH_PATH, return_value=stubbed_response
     ) as mock_http_request:
         limit = 3
-        result = await block.run({"limit": limit})
+        result = await block.run({"channel": FAKE_CHANNEL_ID, "limit": limit})
 
         mock_http_request.assert_called_once_with(
             "https://slack.com/api/conversations.history",
@@ -81,7 +80,7 @@ async def test_when_slack_api_returns_error():
         HTTPX_POST_PATCH_PATH,
         return_value=stubbed_response,
     ), pytest.raises(BlockExecutionError, match="some_error"):
-        await block.run({})
+        await block.run({"channel": FAKE_CHANNEL_ID})
 
 
 @pytest.mark.asyncio()
@@ -93,7 +92,7 @@ async def test_when_slack_api_returns_invalid_data():
         HTTPX_POST_PATCH_PATH,
         return_value=stubbed_response,
     ), pytest.raises(BlockExecutionError, match="data validation"):
-        await block.run({})
+        await block.run({"channel": FAKE_CHANNEL_ID})
 
 
 @pytest.mark.asyncio()
@@ -105,4 +104,4 @@ async def test_when_reqeust_fails():
         HTTPX_POST_PATCH_PATH,
         return_value=stubbed_response,
     ), pytest.raises(BlockExecutionError, match="http request failed"):
-        await block.run({})
+        await block.run({"channel": FAKE_CHANNEL_ID})

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import json
 import uuid
+from pathlib import Path
+from typing import Callable
 from unittest.mock import patch
 
 import pytest
@@ -13,3 +16,14 @@ def freeze_uuid4():  # noqa: ANN201, PT004
     fixed_uuid = uuid.UUID("12345678-1234-5678-1234-567812345678")
     with patch("uuid.uuid4", return_value=fixed_uuid):
         yield
+
+
+@pytest.fixture()
+def get_fixture_data() -> Callable[[str], dict]:
+    def _get_fixture_data(filepath: str) -> dict:
+        path = Path(filepath)
+
+        with path.open("rb") as file_contents:
+            return json.load(file_contents)
+
+    return _get_fixture_data


### PR DESCRIPTION
## Ticket

https://linear.app/scoutshq/issue/PROD-597/block-slack-get-all-channel-messages


## What / Why?

Create new block `scoutos:slack:get_messages` to get slack messages from a given Slack channel.