### PR TITLE
Add fields to `blocks.slack.types.Messages`

### DIFF
--- a/scoutos/blocks/slack/types.py
+++ b/scoutos/blocks/slack/types.py
@@ -37,6 +37,13 @@ class Channel(BaseModel):
 class Message(BaseModel):
     model_config = ConfigDict(extra="allow")
 
+    client_msg_id: str
+    team: str
+    text: str
+    ts: str
+    type: str
+    user: str
+
 
 class ResponseMetadata(BaseModel):
     next_cursor: str | None

--- a/scoutos/blocks/slack/types.py
+++ b/scoutos/blocks/slack/types.py
@@ -38,7 +38,6 @@ class Message(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     client_msg_id: str
-    team: str
     text: str
     ts: str
     type: str


### PR DESCRIPTION
## What / Why?

Add fields to `scoutos.blocks.slack.types.Message`.

I had previously set this to allow all fields to pass-through, but now that we are consuming this, we need some of the output typed to work with it effectively.
